### PR TITLE
Improvements to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,87 @@
 data/*
+!data/.gitkeep
 
-!data/.ignore
+# Created by https://www.gitignore.io/api/linux,macos,windows,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=linux,macos,windows,visualstudiocode
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/linux,macos,windows,visualstudiocode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM: cockroachdb/cockroach:v19.1.4
+FROM cockroachdb/cockroach:v19.1.4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##
+## CockroachDB + PGWeb
 
 ```start.sh```                  Starts cockroachdb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   roach:
     image: cockroachdb/cockroach:v19.1.4
@@ -7,14 +7,12 @@ services:
       - 26257:26257
     volumes:
       - ${PWD}/data:/cockroach/data
-    command: start --insecure --listen-addr=0.0.0.0 --store data 
+    command: start --insecure --listen-addr=0.0.0.0 --store data
   pgweb:
     image: sosedoff/pgweb
-    ports: 
+    ports:
       - 12081:8081
     environment:
-      - DATABASE_URL=postgres://root:@192.168.106.195:26257/postgres?sslmode=disable
-    
-
-    
-
+      - DATABASE_URL=postgres://root:@roach:26257/postgres?sslmode=disable
+    depends_on:
+      - roach

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   roach:
     image: cockroachdb/cockroach:v19.1.4
+    restart: always
     ports:
       - 12080:8080
       - 26257:26257
@@ -10,6 +11,7 @@ services:
     command: start --insecure --listen-addr=0.0.0.0 --store data
   pgweb:
     image: sosedoff/pgweb
+    restart: always
     ports:
       - 12081:8081
     environment:


### PR DESCRIPTION
docker-compose.yml changes:
- Database connection string for pgweb now does not rely on hardcoded IP address
- restart: always flag added for cockroachdb and pgweb
- depends_on flag set so that pgweb will be started after cockroachdb is started

other misc. changes:
- changed .ignore to .gitkeep
- added more generic entries to .gitignore
- fix Dockerfile syntax issue